### PR TITLE
missing headers and additional open-flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+fork
+fork1
+fork3
+hello
+foo.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+
+
+default: all
+
+all: fork fork1 fork3 hello
+
+clean:
+	rm foo.txt

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,9 @@ all: fork fork1 fork3 hello
 
 clean:
 	rm foo.txt
+
+distclean: clean
+	rm fork
+	rm fork1
+	rm fork3
+	rm hello

--- a/fork.c
+++ b/fork.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <sys/types.h>
 #include <unistd.h>
 

--- a/fork1.c
+++ b/fork1.c
@@ -1,6 +1,7 @@
 #include  <stdio.h>
 #include  <string.h>
 #include  <sys/types.h>
+#include  <unistd.h>
 
 #define   MAX_COUNT  200
 #define   BUF_SIZE   100

--- a/fork3.c
+++ b/fork3.c
@@ -11,7 +11,7 @@
 
 int main() {
 
-    int fd = open("foo.txt", O_RDWR | O_TRUNC);
+    int fd = open("foo.txt", O_RDWR | O_TRUNC | O_CREAT, S_IRUSR | S_IWUSR);
 
     int fid = fork();
 


### PR DESCRIPTION
When trying to compile, cc complains about missing headers (unistd.h and stdio.h). 
When foo.txt is non-existing, it does not get created properly, so O_CREAT and permissions. 
For being lazy: .gitignore extended version
For being lazy II: make, make clean (only foo.txt) and make distclean (also binaries)